### PR TITLE
Rebrand site for Eclipse Hub neon service experience

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ALXNE - Professional Account Services</title>
+    <title>Eclipse Hub — Neon Service Delivery</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,7 +35,7 @@ function AppLayout({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen bg-black text-white">
+    <div className="min-h-screen bg-gradient-to-b from-[#050013] via-[#060021] to-[#050013] text-white">
       <Header />
       {children}
       <Footer />

--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -3,37 +3,37 @@ import { Link } from 'react-router-dom';
 
 export default function CTA() {
   return (
-    <section className="py-20 px-6 bg-gradient-to-b from-black to-gray-950">
+    <section className="py-20 px-6 bg-gradient-to-b from-[#050013] via-[#0b0121] to-[#050013]">
       <div className="max-w-7xl mx-auto">
-        <div className="relative bg-gradient-to-br from-gray-500/10 to-gray-600/10 border border-gray-500/20 rounded-2xl p-12 md:p-16 overflow-hidden">
-          <div className="absolute top-0 right-0 w-96 h-96 bg-gray-500/20 rounded-full blur-3xl" />
-          <div className="absolute bottom-0 left-0 w-96 h-96 bg-gray-600/20 rounded-full blur-3xl" />
+        <div className="relative bg-gradient-to-br from-white/10 via-white/5 to-white/10 border border-white/15 rounded-3xl p-12 md:p-16 overflow-hidden shadow-[0_40px_90px_rgba(124,58,237,0.35)]">
+          <div className="absolute top-0 right-0 w-96 h-96 bg-fuchsia-500/30 rounded-full blur-[160px]" />
+          <div className="absolute bottom-0 left-0 w-96 h-96 bg-sky-400/30 rounded-full blur-[160px]" />
 
           <div className="relative z-10 text-center max-w-3xl mx-auto">
             <h2 className="text-4xl md:text-5xl font-bold mb-6">
-              Ready to Get Started?
+              Ready to Glow with Eclipse Hub?
             </h2>
-            <p className="text-xl text-gray-400 mb-10 leading-relaxed">
-              Join thousands of satisfied customers and experience the difference.
-              Start your journey with ALXNE today and unlock premium features instantly.
+            <p className="text-xl text-violet-100/80 mb-10 leading-relaxed">
+              Join the ecosystem powering eclipcestore.digital. Eclipse Hub orchestrates the people, platforms, and processes
+              you need to deliver neon-bright service experiences.
             </p>
 
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link
                 to="/products"
-                className="bg-gradient-to-r from-gray-600 to-gray-500 text-white px-8 py-4 rounded-lg font-medium hover:from-gray-500 hover:to-gray-400 transition-all flex items-center justify-center space-x-2 group shadow-lg shadow-gray-500/25"
+                className="bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white px-8 py-4 rounded-xl font-medium hover:from-fuchsia-400 hover:via-purple-400 hover:to-sky-300 transition-all flex items-center justify-center space-x-2 group shadow-[0_25px_65px_rgba(56,189,248,0.35)]"
               >
-                <span>Browse Products</span>
+                <span>Browse Service Catalog</span>
                 <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
               </Link>
-              <button className="border border-gray-700 text-white px-8 py-4 rounded-lg font-medium hover:bg-gray-900 hover:border-gray-600 transition-all flex items-center justify-center gap-2">
+              <button className="border border-white/20 text-white px-8 py-4 rounded-xl font-medium hover:bg-white/10 hover:border-white/30 transition-all flex items-center justify-center gap-2 backdrop-blur">
                 <MessageCircle className="w-5 h-5" />
-                <span>Contact Sales</span>
+                <span>Contact Eclipse Sales</span>
               </button>
             </div>
 
-            <p className="text-sm text-gray-500 mt-6">
-              No credit card required • 14-day free trial • Cancel anytime
+            <p className="text-sm text-violet-100/70 mt-6">
+              No long-term lock-ins • Custom onboarding sprint • Dedicated success pod
             </p>
           </div>
         </div>

--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -27,9 +27,9 @@ export default function FeaturedProducts() {
 
   if (loading) {
     return (
-      <section className="py-20 px-6 bg-black">
+      <section className="py-20 px-6 bg-[#050013]">
         <div className="max-w-7xl mx-auto">
-          <div className="animate-pulse text-center text-gray-400">Loading featured products...</div>
+          <div className="animate-pulse text-center text-violet-100/70">Loading featured solutions...</div>
         </div>
       </section>
     );
@@ -38,25 +38,27 @@ export default function FeaturedProducts() {
   if (featuredProducts.length === 0) return null;
 
   return (
-    <section className="py-20 px-6 bg-black relative overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-gray-950/30 to-transparent pointer-events-none" />
+    <section className="py-20 px-6 bg-[#050013] relative overflow-hidden">
+      <div className="absolute inset-0 bg-gradient-to-b from-transparent via-purple-500/10 to-transparent pointer-events-none" />
 
       <div className="max-w-7xl mx-auto relative z-10">
         <div className="flex items-center justify-between mb-12">
           <div>
             <div className="flex items-center gap-2 mb-3">
-              <Sparkles className="w-6 h-6 text-white" />
-              <h2 className="text-4xl md:text-5xl font-bold">Featured Products</h2>
+              <Sparkles className="w-6 h-6 text-sky-300" />
+              <h2 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">
+                Featured Solutions
+              </h2>
             </div>
-            <p className="text-xl text-gray-400">
-              Premium selections handpicked for maximum value
+            <p className="text-xl text-violet-100/80">
+              Curated service bundles aligned with the Eclipse Hub delivery blueprint
             </p>
           </div>
           <Link
             to="/products"
-            className="hidden md:flex items-center gap-2 text-gray-400 hover:text-white transition-colors group"
+            className="hidden md:flex items-center gap-2 text-violet-100/80 hover:text-white transition-colors group"
           >
-            <span>View All</span>
+            <span>View All Solutions</span>
             <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
           </Link>
         </div>
@@ -75,9 +77,9 @@ export default function FeaturedProducts() {
 
         <Link
           to="/products"
-          className="md:hidden flex items-center justify-center gap-2 text-gray-400 hover:text-white transition-colors group"
+          className="md:hidden flex items-center justify-center gap-2 text-violet-100/80 hover:text-white transition-colors group"
         >
-          <span>View All Products</span>
+          <span>View All Solutions</span>
           <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
         </Link>
       </div>

--- a/src/components/Features.tsx
+++ b/src/components/Features.tsx
@@ -1,53 +1,52 @@
 import { Check, Zap } from 'lucide-react';
 
 const features = [
-  'End-to-end encryption',
-  'Automated backups',
-  'Custom domain support',
-  'API access',
-  'Advanced analytics',
-  'Team collaboration',
-  'Priority support',
-  'SLA guarantees'
+  'White-label portals and branded touchpoints',
+  'Automated fulfillment workflows',
+  'Secure payment orchestration',
+  'Client journey analytics in real time',
+  'Hybrid human + AI support coverage',
+  'Global compliance alignment',
+  'Dedicated success strategist',
+  'Neon-fast incident response'
 ];
 
 export default function Features() {
   return (
-    <section id="features" className="py-20 px-6 bg-gradient-to-b from-gray-950 to-black relative overflow-hidden">
-      <div className="absolute top-0 right-0 w-96 h-96 bg-gray-500/5 rounded-full blur-3xl" />
+    <section id="features" className="py-20 px-6 bg-gradient-to-b from-[#050013] via-[#0a0127] to-[#050013] relative overflow-hidden">
+      <div className="absolute top-0 right-0 w-96 h-96 bg-purple-500/20 rounded-full blur-[160px]" />
 
       <div className="max-w-7xl mx-auto relative z-10">
         <div className="grid md:grid-cols-2 gap-12 items-center">
           <div>
-            <div className="inline-flex items-center gap-2 mb-4 px-3 py-1 bg-gray-500/10 border border-gray-500/20 rounded-full">
-              <Zap className="w-4 h-4 text-gray-300" />
-              <span className="text-sm text-gray-300 font-medium">Powerful Features</span>
+            <div className="inline-flex items-center gap-2 mb-4 px-3 py-1 bg-white/10 border border-white/20 rounded-full backdrop-blur">
+              <Zap className="w-4 h-4 text-sky-300" />
+              <span className="text-sm text-violet-100/90 font-medium">Built for luminous performance</span>
             </div>
             <h2 className="text-4xl md:text-5xl font-bold mb-6">
               Everything You Need,
               <br />
-              <span className="bg-gradient-to-r from-gray-200 to-gray-400 bg-clip-text text-transparent">
-                Out of the Box
+              <span className="bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">
+                With None of the Friction
               </span>
             </h2>
-            <p className="text-gray-400 text-lg mb-8 leading-relaxed">
-              Built for professionals who demand excellence. Our platform combines
-              cutting-edge technology with intuitive design, trusted by thousands of
-              businesses worldwide.
+            <p className="text-violet-100/80 text-lg mb-8 leading-relaxed">
+              Eclipse Hub merges neon aesthetics with enterprise rigor. Our orchestrated delivery stack keeps your clients
+              thrilled while your team scales effortlessly.
             </p>
-            <button className="bg-gradient-to-r from-gray-600 to-gray-500 text-white px-8 py-3 rounded-lg font-medium hover:from-gray-500 hover:to-gray-400 transition-all shadow-lg shadow-gray-500/25">
-              Discover More
+            <button className="bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white px-8 py-3 rounded-xl font-medium hover:from-fuchsia-400 hover:via-purple-400 hover:to-sky-300 transition-all shadow-[0_20px_50px_rgba(124,58,237,0.35)]">
+              Discover the Eclipse Method
             </button>
           </div>
 
-          <div className="bg-gradient-to-br from-gray-900/80 to-gray-900/40 border border-gray-800 p-8 rounded-lg backdrop-blur-sm">
+          <div className="bg-white/10 border border-white/15 p-8 rounded-2xl backdrop-blur-lg shadow-[0_25px_60px_rgba(56,189,248,0.25)]">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               {features.map((feature, index) => (
                 <div key={index} className="flex items-start space-x-3 group">
-                  <div className="bg-gradient-to-br from-gray-600 to-gray-500 rounded-full p-1 mt-0.5 group-hover:scale-110 transition-transform">
-                    <Check className="w-3 h-3 text-white" strokeWidth={3} />
+                  <div className="bg-gradient-to-br from-fuchsia-400 via-purple-400 to-sky-400 rounded-full p-1.5 mt-0.5 group-hover:scale-110 transition-transform">
+                    <Check className="w-3 h-3 text-[#050013]" strokeWidth={3} />
                   </div>
-                  <span className="text-gray-300 group-hover:text-white transition-colors">{feature}</span>
+                  <span className="text-violet-100/80 group-hover:text-white transition-colors">{feature}</span>
                 </div>
               ))}
             </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,61 +3,63 @@ import { Link } from 'react-router-dom';
 
 export default function Footer() {
   return (
-    <footer id="contact" className="bg-gray-950 border-t border-gray-800 py-12 px-6">
+    <footer id="contact" className="bg-[#040012] border-t border-white/10 py-12 px-6">
       <div className="max-w-7xl mx-auto">
         <div className="grid md:grid-cols-4 gap-8 mb-8">
           <div>
             <div className="flex items-center space-x-2 mb-4">
-              <Shield className="w-6 h-6 text-white" strokeWidth={1.5} />
-              <span className="text-xl font-bold tracking-wider">ALXNE</span>
+              <Shield className="w-6 h-6 text-fuchsia-400" strokeWidth={1.5} />
+              <span className="text-xl font-bold tracking-wider bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">
+                Eclipse Hub
+              </span>
             </div>
-            <p className="text-gray-400 text-sm">
-              Professional account and service provider delivering secure solutions since 2024.
+            <p className="text-violet-100/80 text-sm">
+              Eclipse Hub is your neon-powered partner for designing, launching, and scaling unforgettable service experiences.
             </p>
           </div>
 
           <div>
             <h4 className="font-semibold mb-4">Services</h4>
-            <ul className="space-y-2 text-sm text-gray-400">
-              <li><Link to="/products" className="hover:text-white transition-colors">Products</Link></li>
-              <li><Link to="/how-it-works" className="hover:text-white transition-colors">How It Works</Link></li>
-              <li><Link to="/faq" className="hover:text-white transition-colors">FAQ</Link></li>
+            <ul className="space-y-2 text-sm text-violet-100/70">
+              <li><Link to="/products" className="hover:text-white transition-colors">Service Catalog</Link></li>
+              <li><Link to="/how-it-works" className="hover:text-white transition-colors">How Eclipse Works</Link></li>
+              <li><Link to="/faq" className="hover:text-white transition-colors">FAQs</Link></li>
               <li><Link to="/contact" className="hover:text-white transition-colors">Contact Support</Link></li>
             </ul>
           </div>
 
           <div>
             <h4 className="font-semibold mb-4">Company</h4>
-            <ul className="space-y-2 text-sm text-gray-400">
-              <li><Link to="/how-it-works" className="hover:text-white transition-colors">About Us</Link></li>
+            <ul className="space-y-2 text-sm text-violet-100/70">
+              <li><Link to="/how-it-works" className="hover:text-white transition-colors">About Eclipse Hub</Link></li>
               <li><Link to="/faq" className="hover:text-white transition-colors">Help Center</Link></li>
               <li><Link to="/privacy" className="hover:text-white transition-colors">Privacy Policy</Link></li>
               <li><Link to="/terms" className="hover:text-white transition-colors">Terms of Service</Link></li>
-              <li><Link to="/admin/login" className="hover:text-white transition-colors text-gray-500">Admin Portal</Link></li>
+              <li><Link to="/admin/login" className="hover:text-white transition-colors text-violet-100/60">Admin Portal</Link></li>
             </ul>
           </div>
 
           <div>
             <h4 className="font-semibold mb-4">Contact</h4>
-            <ul className="space-y-3 text-sm text-gray-400">
+            <ul className="space-y-3 text-sm text-violet-100/70">
               <li className="flex items-center space-x-2">
                 <Mail className="w-4 h-4" />
-                <span>contact@alxne.com</span>
+                <span>support@eclipcestore.digital</span>
               </li>
               <li className="flex items-center space-x-2">
                 <Phone className="w-4 h-4" />
-                <span>+1 (555) 123-4567</span>
+                <span>+1 (415) 555-2040</span>
               </li>
               <li className="flex items-center space-x-2">
                 <MapPin className="w-4 h-4" />
-                <span>San Francisco, CA</span>
+                <span>Global · Remote-first</span>
               </li>
             </ul>
           </div>
         </div>
 
-        <div className="pt-8 border-t border-gray-800 text-center text-sm text-gray-400">
-          <p>&copy; 2024 ALXNE. All rights reserved.</p>
+        <div className="pt-8 border-t border-white/10 text-center text-sm text-violet-100/60">
+          <p>&copy; 2024 Eclipse Hub · eclipcestore.digital. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,37 +43,57 @@ export default function Header() {
   };
 
   return (
-    <header className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${scrolled ? 'bg-black/95 border-b border-gray-800/50 shadow-lg' : 'bg-transparent'} backdrop-blur-md`}>
+    <header
+      className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
+        scrolled
+          ? 'bg-[#07001a]/95 border-b border-purple-500/30 shadow-[0_20px_50px_rgba(124,58,237,0.35)]'
+          : 'bg-transparent'
+      } backdrop-blur-xl`}
+    >
       <nav className="max-w-7xl mx-auto px-6 py-4">
         <div className="flex items-center justify-between">
           <Link to="/" className="flex items-center space-x-2 group">
             <div className="relative">
-              <Shield className="w-8 h-8 text-white group-hover:scale-110 transition-transform" strokeWidth={1.5} />
-              <div className="absolute inset-0 bg-gray-500 blur-lg opacity-0 group-hover:opacity-50 transition-opacity" />
+              <Shield className="w-8 h-8 text-fuchsia-400 group-hover:scale-110 transition-transform" strokeWidth={1.5} />
+              <div className="absolute inset-0 bg-fuchsia-500 blur-xl opacity-0 group-hover:opacity-60 transition-opacity" />
             </div>
-            <span className="text-2xl font-bold tracking-wider bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
-              ALXNE
+            <span className="text-2xl font-bold tracking-wider bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">
+              Eclipse Hub
             </span>
           </Link>
 
           <div className="hidden md:flex items-center space-x-6">
             <Link
               to="/"
-              className={`transition-colors ${isActive('/') ? 'text-white font-medium' : 'text-gray-400 hover:text-white'}`}
+              className={`transition-colors ${
+                isActive('/') ? 'text-white font-semibold' : 'text-violet-200/70 hover:text-white'
+              }`}
             >
               Home
             </Link>
             <Link
               to="/products"
-              className={`flex items-center gap-1 transition-colors ${isActive('/products') ? 'text-white font-medium' : 'text-gray-400 hover:text-white'}`}
+              className={`flex items-center gap-1 transition-colors ${
+                isActive('/products')
+                  ? 'text-white font-semibold'
+                  : 'text-violet-200/70 hover:text-white'
+              }`}
             >
               <ShoppingBag className="w-4 h-4" />
-              Products
+              Solutions
             </Link>
-            <a href="#pricing" onClick={(e) => scrollToSection(e, '#pricing')} className="text-gray-400 hover:text-white transition-colors">
-              Pricing
+            <a
+              href="#pricing"
+              onClick={(e) => scrollToSection(e, '#pricing')}
+              className="text-violet-200/70 hover:text-white transition-colors"
+            >
+              Why Eclipse Hub
             </a>
-            <a href="#contact" onClick={(e) => scrollToSection(e, '#contact')} className="text-gray-400 hover:text-white transition-colors">
+            <a
+              href="#contact"
+              onClick={(e) => scrollToSection(e, '#contact')}
+              className="text-violet-200/70 hover:text-white transition-colors"
+            >
               Contact
             </a>
             <NotificationBell />
@@ -82,16 +102,16 @@ export default function Header() {
               <div className="relative">
                 <button
                   onClick={() => setUserMenuOpen(!userMenuOpen)}
-                  className="flex items-center gap-2 px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg hover:bg-gray-700 transition-colors"
+                  className="flex items-center gap-2 px-4 py-2 bg-[#120437]/80 border border-purple-500/40 rounded-lg hover:bg-[#1c0652]/80 transition-colors"
                 >
                   <User className="w-4 h-4" />
                   <span className="text-sm">{user.email?.split('@')[0]}</span>
                 </button>
                 {userMenuOpen && (
-                  <div className="absolute right-0 mt-2 w-48 bg-gray-900 border border-gray-800 rounded-lg shadow-xl animate-in">
+                  <div className="absolute right-0 mt-2 w-48 bg-[#0b011f]/95 border border-purple-500/30 rounded-xl shadow-[0_20px_45px_rgba(124,58,237,0.35)] animate-in">
                     <Link
                       to="/dashboard"
-                      className="block px-4 py-2 text-gray-300 hover:bg-gray-800 transition-colors flex items-center gap-2"
+                      className="block px-4 py-2 text-violet-100/80 hover:bg-purple-600/20 transition-colors flex items-center gap-2"
                       onClick={() => setUserMenuOpen(false)}
                     >
                       <LayoutDashboard className="w-4 h-4" />
@@ -99,21 +119,21 @@ export default function Header() {
                     </Link>
                     <Link
                       to="/profile"
-                      className="block px-4 py-2 text-gray-300 hover:bg-gray-800 transition-colors"
+                      className="block px-4 py-2 text-violet-100/80 hover:bg-purple-600/20 transition-colors"
                       onClick={() => setUserMenuOpen(false)}
                     >
                       My Profile
                     </Link>
                     <Link
                       to="/orders"
-                      className="block px-4 py-2 text-gray-300 hover:bg-gray-800 transition-colors"
+                      className="block px-4 py-2 text-violet-100/80 hover:bg-purple-600/20 transition-colors"
                       onClick={() => setUserMenuOpen(false)}
                     >
                       My Orders
                     </Link>
                     <Link
                       to="/wishlist"
-                      className="block px-4 py-2 text-gray-300 hover:bg-gray-800 transition-colors"
+                      className="block px-4 py-2 text-violet-100/80 hover:bg-purple-600/20 transition-colors"
                       onClick={() => setUserMenuOpen(false)}
                     >
                       Wishlist
@@ -123,7 +143,7 @@ export default function Header() {
                         signOut();
                         setUserMenuOpen(false);
                       }}
-                      className="w-full text-left px-4 py-2 text-red-400 hover:bg-gray-800 transition-colors flex items-center gap-2"
+                      className="w-full text-left px-4 py-2 text-rose-400 hover:bg-purple-600/20 transition-colors flex items-center gap-2"
                     >
                       <LogOut className="w-4 h-4" />
                       Sign Out
@@ -134,9 +154,9 @@ export default function Header() {
             ) : (
               <button
                 onClick={() => setAuthModalOpen(true)}
-                className="bg-gradient-to-r from-gray-600 to-gray-500 text-white px-6 py-2 rounded-lg font-medium hover:from-gray-500 hover:to-gray-400 transition-all hover:scale-105 shadow-lg shadow-gray-500/25"
+                className="bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white px-6 py-2 rounded-lg font-medium hover:from-fuchsia-400 hover:via-purple-400 hover:to-sky-300 transition-all hover:scale-105 shadow-[0_15px_40px_rgba(56,189,248,0.35)]"
               >
-                Get Started
+                Partner with Us
               </button>
             )}
           </div>
@@ -154,25 +174,48 @@ export default function Header() {
 
         {mobileMenuOpen && (
           <div className="md:hidden mt-4 pb-4 space-y-4 animate-in slide-in-from-top">
-            <Link to="/" className="block text-gray-300 hover:text-white transition-colors">Home</Link>
-            <Link to="/products" className="block text-gray-300 hover:text-white transition-colors flex items-center gap-2">
-              <ShoppingBag className="w-4 h-4" />
-              Products
+            <Link to="/" className="block text-violet-100/80 hover:text-white transition-colors">
+              Home
             </Link>
-            <a href="#pricing" onClick={(e) => scrollToSection(e, '#pricing')} className="block text-gray-300 hover:text-white transition-colors">Pricing</a>
-            <a href="#contact" onClick={(e) => scrollToSection(e, '#contact')} className="block text-gray-300 hover:text-white transition-colors">Contact</a>
+            <Link to="/products" className="block text-violet-100/80 hover:text-white transition-colors flex items-center gap-2">
+              <ShoppingBag className="w-4 h-4" />
+              Solutions
+            </Link>
+            <a
+              href="#pricing"
+              onClick={(e) => scrollToSection(e, '#pricing')}
+              className="block text-violet-100/80 hover:text-white transition-colors"
+            >
+              Why Eclipse Hub
+            </a>
+            <a
+              href="#contact"
+              onClick={(e) => scrollToSection(e, '#contact')}
+              className="block text-violet-100/80 hover:text-white transition-colors"
+            >
+              Contact
+            </a>
             {user ? (
               <>
-                <Link to="/dashboard" className="block text-gray-300 hover:text-white transition-colors flex items-center gap-2">
+                <Link
+                  to="/dashboard"
+                  className="block text-violet-100/80 hover:text-white transition-colors flex items-center gap-2"
+                >
                   <LayoutDashboard className="w-4 h-4" />
                   Dashboard
                 </Link>
-                <Link to="/profile" className="block text-gray-300 hover:text-white transition-colors">My Profile</Link>
-                <Link to="/orders" className="block text-gray-300 hover:text-white transition-colors">My Orders</Link>
-                <Link to="/wishlist" className="block text-gray-300 hover:text-white transition-colors">Wishlist</Link>
+                <Link to="/profile" className="block text-violet-100/80 hover:text-white transition-colors">
+                  My Profile
+                </Link>
+                <Link to="/orders" className="block text-violet-100/80 hover:text-white transition-colors">
+                  My Orders
+                </Link>
+                <Link to="/wishlist" className="block text-violet-100/80 hover:text-white transition-colors">
+                  Wishlist
+                </Link>
                 <button
                   onClick={signOut}
-                  className="w-full bg-red-600 text-white px-6 py-2 rounded-lg font-medium hover:bg-red-500 transition-all flex items-center justify-center gap-2"
+                  className="w-full bg-gradient-to-r from-rose-500 to-fuchsia-500 text-white px-6 py-2 rounded-lg font-medium hover:from-rose-400 hover:to-fuchsia-400 transition-all flex items-center justify-center gap-2"
                 >
                   <LogOut className="w-4 h-4" />
                   Sign Out
@@ -181,9 +224,9 @@ export default function Header() {
             ) : (
               <button
                 onClick={() => setAuthModalOpen(true)}
-                className="w-full bg-gradient-to-r from-gray-600 to-gray-500 text-white px-6 py-2 rounded-lg font-medium hover:from-gray-500 hover:to-gray-400 transition-all shadow-lg shadow-gray-500/25"
+                className="w-full bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white px-6 py-2 rounded-lg font-medium hover:from-fuchsia-400 hover:via-purple-400 hover:to-sky-300 transition-all shadow-[0_15px_40px_rgba(56,189,248,0.35)]"
               >
-                Get Started
+                Partner with Us
               </button>
             )}
           </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,55 +4,56 @@ import { Link } from 'react-router-dom';
 export default function Hero() {
   return (
     <section className="relative pt-32 pb-20 px-6 overflow-hidden">
-      <div className="absolute inset-0 bg-gradient-to-br from-gray-500/5 via-transparent to-gray-600/5 pointer-events-none" />
-      <div className="absolute top-20 left-10 w-72 h-72 bg-gray-500/10 rounded-full blur-3xl" />
-      <div className="absolute bottom-20 right-10 w-96 h-96 bg-gray-600/10 rounded-full blur-3xl" />
+      <div className="absolute inset-0 bg-gradient-to-br from-[#0a0020] via-[#14003d] to-[#03000f]" />
+      <div className="absolute -top-10 -left-10 w-80 h-80 bg-fuchsia-500/30 rounded-full blur-[160px]" />
+      <div className="absolute top-1/3 right-0 w-[36rem] h-[36rem] bg-sky-400/20 rounded-full blur-[180px]" />
+      <div className="absolute bottom-0 left-1/4 w-[28rem] h-[28rem] bg-purple-500/30 rounded-full blur-[160px]" />
 
       <div className="max-w-7xl mx-auto relative z-10">
         <div className="max-w-4xl mx-auto text-center">
-          <div className="inline-flex items-center gap-2 mb-6 px-4 py-2 bg-gradient-to-r from-gray-500/10 to-gray-600/10 border border-gray-500/20 rounded-full">
-            <Sparkles className="w-4 h-4 text-gray-300" />
-            <span className="text-sm text-gray-300 font-medium">Welcome to the Future of Account Management</span>
+          <div className="inline-flex items-center gap-2 mb-6 px-4 py-2 bg-white/5 border border-white/10 rounded-full backdrop-blur">
+            <Sparkles className="w-4 h-4 text-sky-300" />
+            <span className="text-sm text-violet-100/90 font-medium">Eclipcestore.digital — the official Eclipse Hub network</span>
           </div>
 
           <h1 className="text-5xl md:text-7xl lg:text-8xl font-bold mb-6 tracking-tight leading-tight">
-            Your Digital Life,
+            Service Delivery,
             <br />
-            <span className="bg-gradient-to-r from-gray-200 via-gray-300 to-gray-400 bg-clip-text text-transparent">
-              Simplified
+            <span className="bg-gradient-to-r from-fuchsia-400 via-purple-300 to-sky-300 bg-clip-text text-transparent">
+              Reimagined by Eclipse Hub
             </span>
           </h1>
 
-          <p className="text-xl md:text-2xl text-gray-400 mb-10 leading-relaxed max-w-3xl mx-auto">
-            Experience seamless account management with enterprise-grade security.
-            Join thousands of satisfied users who trust ALXNE for their digital needs.
+          <p className="text-xl md:text-2xl text-violet-100/80 mb-10 leading-relaxed max-w-3xl mx-auto">
+            We design, launch, and manage digital services for creators, agencies, and modern brands. From onboarding to
+            secure delivery, Eclipse Hub keeps your operations glowing around the clock.
           </p>
 
           <div className="flex flex-col sm:flex-row gap-4 justify-center mb-12">
             <Link
               to="/products"
-              className="bg-gradient-to-r from-gray-600 to-gray-500 text-white px-8 py-4 rounded-lg font-medium hover:from-gray-500 hover:to-gray-400 transition-all flex items-center justify-center space-x-2 group shadow-lg shadow-gray-500/25"
+              className="bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white px-8 py-4 rounded-xl font-medium hover:from-fuchsia-400 hover:via-purple-400 hover:to-sky-300 transition-all flex items-center justify-center space-x-2 group shadow-[0_25px_65px_rgba(124,58,237,0.45)]"
             >
-              <span>Explore Products</span>
+              <span>Explore Service Catalog</span>
               <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
             </Link>
             <a
               href="#services"
-              className="border border-gray-700 text-white px-8 py-4 rounded-lg font-medium hover:bg-gray-900 hover:border-gray-600 transition-all"
+              className="px-8 py-4 rounded-xl font-medium border border-white/20 text-white hover:bg-white/10 transition-all backdrop-blur"
             >
-              Learn More
+              How We Work
             </a>
           </div>
 
-          <div className="flex flex-wrap items-center justify-center gap-6 text-sm text-gray-500">
+          <div className="flex flex-wrap items-center justify-center gap-6 text-sm text-violet-100/70">
             <div className="flex items-center gap-2">
-              <div className="w-2 h-2 bg-green-500 rounded-full animate-pulse" />
-              <span>All systems operational</span>
+              <div className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse" />
+              <span>Live orchestration status: Operational</span>
             </div>
-            <div className="hidden sm:block w-1 h-1 bg-gray-700 rounded-full" />
-            <span>Trusted by 50,000+ users</span>
-            <div className="hidden sm:block w-1 h-1 bg-gray-700 rounded-full" />
-            <span>99.9% uptime guarantee</span>
+            <div className="hidden sm:block w-1 h-1 bg-white/20 rounded-full" />
+            <span>2,500+ launches powered in 2024</span>
+            <div className="hidden sm:block w-1 h-1 bg-white/20 rounded-full" />
+            <span>99.98% service uptime</span>
           </div>
         </div>
       </div>

--- a/src/components/Pricing.tsx
+++ b/src/components/Pricing.tsx
@@ -4,52 +4,52 @@ import { useState, useEffect } from 'react';
 const features = [
   {
     icon: Download,
-    title: 'Instant Delivery',
-    description: 'All products are immediately available for download after purchase.',
+    title: 'Lightning Launch Velocity',
+    description: 'Spin up new service lines in days, not months, with automation across onboarding and fulfillment.',
     stats: [
-      { label: 'Delivery Speed', value: '< 1 second' },
-      { label: 'Success Rate', value: '99.9%' },
-      { label: 'Downloads/Day', value: '1,000+' }
+      { label: 'Average go-live', value: '5 days' },
+      { label: 'Automation coverage', value: '92%' },
+      { label: 'Launches/Month', value: '200+' }
     ]
   },
   {
     icon: Shield,
-    title: 'Safe & Undetected',
-    description: 'We provide the most secure and undetected products on the market.',
+    title: 'Trust & Compliance Layer',
+    description: 'Compliance-ready infrastructure with encryption, auditing, and global data residency controls.',
     stats: [
-      { label: 'Detection Rate', value: '0.0%' },
-      { label: 'Last Update', value: '2 hours ago' },
-      { label: 'Active Users', value: '50,000+' }
+      { label: 'Security incidents', value: '0' },
+      { label: 'Regions covered', value: '12' },
+      { label: 'Certifications', value: 'SOC2, ISO' }
     ]
   },
   {
     icon: Settings,
-    title: 'Save & Share Configs',
-    description: 'Easily save your configs and share them, or use community setups.',
+    title: 'Adaptive Workflows',
+    description: 'Dynamic configuration engine keeps every client journey in sync with your processes and brand voice.',
     stats: [
-      { label: 'Config Storage', value: 'Unlimited' },
-      { label: 'Community Configs', value: '10,000+' },
-      { label: 'Auto-Sync', value: 'Enabled' }
+      { label: 'Workflow variations', value: '500+' },
+      { label: 'Brand accuracy', value: '99%' },
+      { label: 'Updates pushed', value: 'Realtime' }
     ]
   },
   {
     icon: CreditCard,
-    title: 'Secure Payment Methods',
-    description: 'All transactions are processed through trusted payment gateways to ensure maximum safety and reliability.',
+    title: 'Revenue Resilience',
+    description: 'Orchestrated billing with smart retries, localized payments, and deep financial reporting.',
     stats: [
-      { label: 'Payment Options', value: '10+' },
-      { label: 'Encryption', value: 'AES-256' },
-      { label: 'Transactions', value: '100K+' }
+      { label: 'Payment uptime', value: '99.99%' },
+      { label: 'Payment methods', value: '18' },
+      { label: 'Recovered revenue', value: '$2.3M' }
     ]
   },
   {
     icon: Eye,
-    title: 'Easy Setup',
-    description: 'Our products are built for a smooth, user-friendly experience, any user can set up and use our cheats with ease.',
+    title: 'Clarity & Oversight',
+    description: 'Unified observability dashboards track every handoff, SLA, and customer milestone in real-time.',
     stats: [
-      { label: 'Setup Time', value: '< 2 minutes' },
-      { label: 'User Rating', value: '4.9/5.0' },
-      { label: 'Support Available', value: '24/7' }
+      { label: 'SLA adherence', value: '99.8%' },
+      { label: 'Insights refreshed', value: '30s' },
+      { label: 'Stakeholder seats', value: 'Unlimited' }
     ]
   }
 ];
@@ -85,17 +85,18 @@ export default function Pricing() {
   const activeFeature = features[activeIndex];
 
   return (
-    <section id="pricing" className="py-20 px-6 bg-gradient-to-b from-black via-gray-950 to-black relative overflow-hidden">
-      <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-gray-500/5 rounded-full blur-3xl" />
-      <div className="absolute bottom-1/4 right-1/4 w-96 h-96 bg-gray-600/5 rounded-full blur-3xl" />
+    <section id="pricing" className="py-20 px-6 bg-gradient-to-b from-[#050013] via-[#0e012f] to-[#050013] relative overflow-hidden">
+      <div className="absolute top-1/4 left-1/4 w-96 h-96 bg-fuchsia-500/20 rounded-full blur-[160px]" />
+      <div className="absolute bottom-1/4 right-1/4 w-[28rem] h-[28rem] bg-sky-400/20 rounded-full blur-[200px]" />
 
       <div className="max-w-7xl mx-auto relative z-10">
         <div className="text-center mb-16 animate-fade-in">
           <h2 className="text-5xl md:text-6xl font-bold mb-6">
-            Why Choose <span className="bg-gradient-to-r from-gray-200 via-gray-300 to-gray-400 bg-clip-text text-transparent">Us?</span>
+            Why Teams Choose <span className="bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">Eclipse Hub</span>
           </h2>
-          <p className="text-gray-400 text-lg max-w-3xl mx-auto leading-relaxed">
-            Experience unmatched service quality. Our dedicated team is here around the clock to support you and simplify every step of the process.
+          <p className="text-violet-100/80 text-lg max-w-3xl mx-auto leading-relaxed">
+            Experience neon-grade clarity paired with enterprise discipline. Eclipse Hub synchronizes your service delivery,
+            so you can scale without sacrificing trust.
           </p>
         </div>
 
@@ -104,18 +105,18 @@ export default function Pricing() {
           {/* Navigation Buttons */}
           <button
             onClick={goToPrevious}
-            className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-4 md:-translate-x-12 z-20 bg-gray-900/80 border border-gray-700 p-3 rounded-full hover:bg-gray-800 hover:border-gray-600 transition-all hover:scale-110 backdrop-blur-sm"
+            className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-4 md:-translate-x-12 z-20 bg-white/10 border border-white/20 p-3 rounded-full hover:bg-fuchsia-500/20 hover:border-fuchsia-400/40 transition-all hover:scale-110 backdrop-blur-sm"
             aria-label="Previous feature"
           >
-            <ChevronLeft className="w-6 h-6 text-gray-300" />
+            <ChevronLeft className="w-6 h-6 text-white" />
           </button>
 
           <button
             onClick={goToNext}
-            className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-4 md:translate-x-12 z-20 bg-gray-900/80 border border-gray-700 p-3 rounded-full hover:bg-gray-800 hover:border-gray-600 transition-all hover:scale-110 backdrop-blur-sm"
+            className="absolute right-0 top-1/2 -translate-y-1/2 translate-x-4 md:translate-x-12 z-20 bg-white/10 border border-white/20 p-3 rounded-full hover:bg-fuchsia-500/20 hover:border-fuchsia-400/40 transition-all hover:scale-110 backdrop-blur-sm"
             aria-label="Next feature"
           >
-            <ChevronRight className="w-6 h-6 text-gray-300" />
+            <ChevronRight className="w-6 h-6 text-white" />
           </button>
 
           {/* Carousel Content */}
@@ -131,31 +132,31 @@ export default function Pricing() {
                     : 'opacity-0 translate-x-full'
                 }`}
               >
-                <div className="relative bg-gradient-to-br from-gray-900/90 via-gray-900/50 to-gray-900/90 border border-gray-700 p-12 rounded-2xl overflow-hidden shadow-2xl shadow-gray-500/20 h-full">
+                <div className="relative bg-gradient-to-br from-white/10 via-white/5 to-white/10 border border-white/15 p-12 rounded-2xl overflow-hidden shadow-[0_30px_80px_rgba(124,58,237,0.35)] h-full">
                   {/* Animated border shimmer */}
                   <div className="absolute inset-0 opacity-100">
-                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-gray-500/20 to-transparent translate-x-[-200%] animate-shimmer" />
+                    <div className="absolute inset-0 bg-gradient-to-r from-transparent via-fuchsia-400/30 to-transparent translate-x-[-200%] animate-shimmer" />
                   </div>
 
                   {/* Animated background gradient */}
-                  <div className="absolute inset-0 bg-gradient-to-br from-gray-600/5 to-gray-500/5 opacity-50" />
+                  <div className="absolute inset-0 bg-gradient-to-br from-fuchsia-500/10 to-sky-400/10 opacity-60" />
 
                   <div className="relative z-10 flex flex-col items-center text-center">
                     {/* Icon */}
                     <div className="mb-8 relative">
-                      <div className="w-32 h-32 rounded-3xl bg-gradient-to-br from-gray-600 to-gray-500 opacity-10 absolute inset-0 blur-2xl animate-pulse" />
-                      <div className="w-32 h-32 rounded-3xl bg-gradient-to-br from-gray-600 to-gray-500 p-6 relative flex items-center justify-center">
+                      <div className="w-32 h-32 rounded-3xl bg-gradient-to-br from-fuchsia-500 to-sky-400 opacity-20 absolute inset-0 blur-2xl animate-pulse" />
+                      <div className="w-32 h-32 rounded-3xl bg-gradient-to-br from-fuchsia-500 via-purple-500 to-sky-400 p-6 relative flex items-center justify-center">
                         <feature.icon className="w-16 h-16 text-white" />
                       </div>
                     </div>
 
                     {/* Title */}
-                    <h3 className="text-3xl md:text-4xl font-bold mb-4 bg-gradient-to-r from-white to-gray-300 bg-clip-text text-transparent">
+                    <h3 className="text-3xl md:text-4xl font-bold mb-4 bg-gradient-to-r from-white via-purple-100 to-sky-100 bg-clip-text text-transparent">
                       {feature.title}
                     </h3>
 
                     {/* Description */}
-                    <p className="text-gray-400 text-lg leading-relaxed mb-10 max-w-2xl">
+                    <p className="text-violet-100/80 text-lg leading-relaxed mb-10 max-w-2xl">
                       {feature.description}
                     </p>
 
@@ -164,17 +165,17 @@ export default function Pricing() {
                       {feature.stats.map((stat, statIndex) => (
                         <div
                           key={statIndex}
-                          className="bg-gray-800/50 rounded-xl border border-gray-700 p-6 transition-all duration-500 hover:border-gray-600 hover:bg-gray-800/70"
+                          className="bg-white/10 rounded-xl border border-white/15 p-6 transition-all duration-500 hover:border-fuchsia-400/50 hover:bg-fuchsia-500/10"
                           style={{
                             animation: 'slideUp 0.6s ease-out forwards',
                             animationDelay: `${statIndex * 100 + 200}ms`,
                             opacity: 0
                           }}
                         >
-                          <div className="text-3xl font-bold text-white mb-2 bg-gradient-to-r from-gray-200 to-gray-400 bg-clip-text text-transparent">
+                          <div className="text-3xl font-bold text-white mb-2 bg-gradient-to-r from-fuchsia-200 via-purple-100 to-sky-200 bg-clip-text text-transparent">
                             {stat.value}
                           </div>
-                          <div className="text-sm text-gray-500 font-medium">
+                          <div className="text-sm text-violet-100/70 font-medium">
                             {stat.label}
                           </div>
                         </div>
@@ -195,8 +196,8 @@ export default function Pricing() {
               onClick={() => goToSlide(index)}
               className={`h-3 rounded-full transition-all duration-500 ${
                 activeIndex === index
-                  ? 'w-12 bg-gradient-to-r from-gray-600 to-gray-500'
-                  : 'w-3 bg-gray-800 hover:bg-gray-700'
+                  ? 'w-12 bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400'
+                  : 'w-3 bg-white/20 hover:bg-white/40'
               }`}
               aria-label={`View feature ${index + 1}`}
             />
@@ -204,10 +205,10 @@ export default function Pricing() {
         </div>
 
         <div className="mt-16 text-center animate-fade-in" style={{ animationDelay: '500ms' }}>
-          <div className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-gray-800/50 to-gray-900/50 border border-gray-700 rounded-full backdrop-blur-sm group hover:border-gray-600 transition-all cursor-pointer">
-            <Zap className="w-5 h-5 text-gray-400 group-hover:text-white transition-colors" />
-            <span className="text-gray-300 font-medium group-hover:text-white transition-colors">All features included in every product</span>
-            <ChevronRight className="w-4 h-4 text-gray-500 group-hover:translate-x-1 transition-transform" />
+          <div className="inline-flex items-center gap-2 px-6 py-3 bg-white/10 border border-white/20 rounded-full backdrop-blur-xl group hover:border-fuchsia-400/40 transition-all cursor-pointer">
+            <Zap className="w-5 h-5 text-sky-300 group-hover:text-white transition-colors" />
+            <span className="text-violet-100/80 font-medium group-hover:text-white transition-colors">Every partnership unlocks the full Eclipse Hub stack</span>
+            <ChevronRight className="w-4 h-4 text-violet-100/60 group-hover:translate-x-1 transition-transform" />
           </div>
         </div>
       </div>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -1,42 +1,42 @@
-import { Shield, Lock, Users, Headphones, ArrowRight } from 'lucide-react';
+import { Lock, Users, Headphones, ArrowRight, Sparkles } from 'lucide-react';
 
 const services = [
   {
-    icon: Shield,
-    title: 'Account Management',
-    description: 'Comprehensive account lifecycle management with advanced security protocols and automated workflows.',
-    color: 'from-gray-500/20 to-gray-600/20'
+    icon: Sparkles,
+    title: 'Service Launch Architecture',
+    description: 'Blueprint, package, and launch your offers with our battle-tested frameworks, from onboarding to fulfillment.',
+    color: 'from-fuchsia-500/20 to-purple-500/20'
   },
   {
     icon: Lock,
-    title: 'Security Solutions',
-    description: 'Enterprise-grade encryption, two-factor authentication, and continuous monitoring for maximum protection.',
-    color: 'from-gray-600/20 to-gray-500/20'
+    title: 'Secure Delivery Infrastructure',
+    description: 'Enterprise-grade protection, access controls, and observability keep every client touchpoint safeguarded.',
+    color: 'from-purple-500/20 to-sky-500/20'
   },
   {
     icon: Users,
-    title: 'Multi-User Support',
-    description: 'Scalable solutions for teams and organizations with role-based access control and permissions.',
-    color: 'from-gray-500/20 to-gray-700/20'
+    title: 'Customer Success Pods',
+    description: 'Dedicated pods embedded with your team to manage escalations, retention campaigns, and loyalty programs.',
+    color: 'from-sky-500/20 to-fuchsia-500/20'
   },
   {
     icon: Headphones,
-    title: '24/7 Support',
-    description: 'Round-the-clock technical support and dedicated account managers for enterprise clients.',
-    color: 'from-gray-700/20 to-gray-500/20'
+    title: '24/7 Neon Support Desk',
+    description: 'Always-on support with live response SLAs, multilingual coverage, and proactive service checks.',
+    color: 'from-purple-500/20 to-emerald-500/20'
   }
 ];
 
 export default function Services() {
   return (
-    <section id="services" className="py-20 px-6 bg-gradient-to-b from-black to-gray-950">
+    <section id="services" className="py-20 px-6 bg-gradient-to-b from-[#050013] via-[#0b0121] to-[#050013]">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold mb-4">
-            What We <span className="bg-gradient-to-r from-gray-200 to-gray-400 bg-clip-text text-transparent">Offer</span>
+            What Eclipse Hub <span className="bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">Delivers</span>
           </h2>
-          <p className="text-gray-400 text-lg max-w-2xl mx-auto">
-            Professional solutions designed to elevate your business
+          <p className="text-violet-100/80 text-lg max-w-2xl mx-auto">
+            Modular service layers tuned for scale, security, and unforgettable client experiences.
           </p>
         </div>
 
@@ -46,18 +46,20 @@ export default function Services() {
             return (
               <div
                 key={index}
-                className="bg-gradient-to-br from-gray-900/50 to-gray-900/30 border border-gray-800 p-8 rounded-lg hover:border-gray-700 transition-all group relative overflow-hidden"
+                className="bg-gradient-to-br from-white/5 to-white/10 border border-white/10 p-8 rounded-2xl hover:border-fuchsia-400/40 transition-all group relative overflow-hidden shadow-[0_25px_45px_rgba(79,70,229,0.2)]"
               >
-                <div className={`absolute inset-0 bg-gradient-to-br ${service.color} opacity-0 group-hover:opacity-100 transition-opacity duration-500`} />
+                <div
+                  className={`absolute inset-0 bg-gradient-to-br ${service.color} opacity-0 group-hover:opacity-100 transition-opacity duration-500 blur-2xl`}
+                />
 
                 <div className="relative z-10">
-                  <div className="mb-4 inline-flex p-3 bg-gradient-to-br from-gray-800 to-gray-700 rounded-lg group-hover:scale-110 transition-transform">
-                    <Icon className="w-6 h-6 text-gray-300" strokeWidth={1.5} />
+                  <div className="mb-4 inline-flex p-3 bg-gradient-to-br from-fuchsia-500/40 via-purple-500/40 to-sky-400/40 rounded-xl group-hover:scale-110 transition-transform">
+                    <Icon className="w-6 h-6 text-white" strokeWidth={1.5} />
                   </div>
                   <h3 className="text-xl font-semibold mb-3">{service.title}</h3>
-                  <p className="text-gray-400 leading-relaxed mb-4">{service.description}</p>
-                  <div className="flex items-center text-gray-300 text-sm font-medium opacity-0 group-hover:opacity-100 transition-opacity">
-                    <span>Learn more</span>
+                  <p className="text-violet-100/80 leading-relaxed mb-4">{service.description}</p>
+                  <div className="flex items-center text-sky-200 text-sm font-medium opacity-0 group-hover:opacity-100 transition-opacity">
+                    <span>Dive into the workflow</span>
                     <ArrowRight className="w-4 h-4 ml-1 group-hover:translate-x-1 transition-transform" />
                   </div>
                 </div>

--- a/src/components/Testimonials.tsx
+++ b/src/components/Testimonials.tsx
@@ -4,21 +4,21 @@ const testimonials = [
   {
     name: 'Sarah Chen',
     role: 'CTO, TechCorp',
-    content: 'ALXNE has transformed how we manage our accounts. The security features are top-notch and the support team is incredibly responsive.',
+    content: 'Eclipse Hub transformed our launch schedule. The neon dashboard keeps my team aligned and confident every step.',
     rating: 5,
     avatar: 'https://images.pexels.com/photos/774909/pexels-photo-774909.jpeg?auto=compress&cs=tinysrgb&w=200'
   },
   {
     name: 'Marcus Johnson',
     role: 'Founder, StartupHub',
-    content: 'Best investment we made this year. The API integration was seamless and saved us months of development time.',
+    content: 'Best decision of the year. We went live in days and the customer success pod feels like an extension of our team.',
     rating: 5,
     avatar: 'https://images.pexels.com/photos/1222271/pexels-photo-1222271.jpeg?auto=compress&cs=tinysrgb&w=200'
   },
   {
     name: 'Elena Rodriguez',
     role: 'Product Manager, CloudSync',
-    content: 'Professional, reliable, and feature-rich. ALXNE exceeded our expectations in every way. Highly recommended!',
+    content: 'Professional, reliable, and vibrant. Eclipse Hub keeps every touchpoint on-brand and every SLA on time.',
     rating: 5,
     avatar: 'https://images.pexels.com/photos/1181424/pexels-photo-1181424.jpeg?auto=compress&cs=tinysrgb&w=200'
   }
@@ -26,14 +26,14 @@ const testimonials = [
 
 export default function Testimonials() {
   return (
-    <section className="py-20 px-6 bg-gradient-to-b from-black to-gray-950">
+    <section className="py-20 px-6 bg-gradient-to-b from-[#050013] via-[#0a0127] to-[#050013]">
       <div className="max-w-7xl mx-auto">
         <div className="text-center mb-16">
           <h2 className="text-4xl md:text-5xl font-bold mb-4">
-            Trusted by <span className="bg-gradient-to-r from-blue-400 to-cyan-400 bg-clip-text text-transparent">Thousands</span>
+            Trusted by <span className="bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">Trailblazers</span>
           </h2>
-          <p className="text-xl text-gray-400">
-            See what our customers have to say about their experience
+          <p className="text-xl text-violet-100/80">
+            See how partners are scaling service delivery with Eclipse Hub
           </p>
         </div>
 
@@ -41,9 +41,9 @@ export default function Testimonials() {
           {testimonials.map((testimonial, index) => (
             <div
               key={index}
-              className="bg-gradient-to-br from-gray-900/50 to-gray-900/30 border border-gray-800 p-8 rounded-lg hover:border-gray-700 transition-all group relative"
+              className="bg-gradient-to-br from-white/10 via-white/5 to-white/10 border border-white/15 p-8 rounded-2xl hover:border-fuchsia-400/40 transition-all group relative shadow-[0_25px_60px_rgba(56,189,248,0.25)]"
             >
-              <Quote className="absolute top-4 right-4 w-8 h-8 text-gray-800 group-hover:text-gray-700 transition-colors" />
+              <Quote className="absolute top-4 right-4 w-8 h-8 text-fuchsia-500/40 group-hover:text-sky-400/60 transition-colors" />
 
               <div className="flex items-center gap-1 mb-4">
                 {Array.from({ length: testimonial.rating }).map((_, i) => (
@@ -51,7 +51,7 @@ export default function Testimonials() {
                 ))}
               </div>
 
-              <p className="text-gray-300 mb-6 leading-relaxed relative z-10">
+              <p className="text-violet-100/80 mb-6 leading-relaxed relative z-10">
                 "{testimonial.content}"
               </p>
 
@@ -59,11 +59,11 @@ export default function Testimonials() {
                 <img
                   src={testimonial.avatar}
                   alt={testimonial.name}
-                  className="w-12 h-12 rounded-full object-cover ring-2 ring-gray-800"
+                  className="w-12 h-12 rounded-full object-cover ring-2 ring-fuchsia-400/30"
                 />
                 <div>
                   <div className="font-semibold">{testimonial.name}</div>
-                  <div className="text-sm text-gray-400">{testimonial.role}</div>
+                  <div className="text-sm text-violet-100/70">{testimonial.role}</div>
                 </div>
               </div>
             </div>

--- a/src/config/admin.ts
+++ b/src/config/admin.ts
@@ -1,6 +1,6 @@
 // Admin credentials - In production, use environment variables
 export const ADMIN_CREDENTIALS = {
-  email: import.meta.env.VITE_ADMIN_EMAIL || 'admin@alxne.com',
+  email: import.meta.env.VITE_ADMIN_EMAIL || 'admin@eclipcestore.digital',
   password: import.meta.env.VITE_ADMIN_PASSWORD || 'Admin123!@#',
 };
 

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,8 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow-x: hidden;
+  background-color: #050013;
+  color: #f8f7ff;
 }
 
 .line-clamp-1 {
@@ -171,14 +173,14 @@ select:focus {
 
 @layer utilities {
   .text-gradient {
-    @apply bg-gradient-to-r from-gray-200 via-gray-300 to-gray-400 bg-clip-text text-transparent;
+    @apply bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent;
   }
 
   .btn-gradient {
-    @apply bg-gradient-to-r from-gray-600 to-gray-500 text-white hover:from-gray-500 hover:to-gray-400 transition-all shadow-lg shadow-gray-500/25;
+    @apply bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white hover:from-fuchsia-400 hover:via-purple-400 hover:to-sky-300 transition-all shadow-[0_20px_50px_rgba(124,58,237,0.35)];
   }
 
   .card-gradient {
-    @apply bg-gradient-to-br from-gray-900/80 to-gray-900/40 border border-gray-800 hover:border-gray-700 transition-all;
+    @apply bg-gradient-to-br from-white/10 via-white/5 to-white/10 border border-white/15 hover:border-fuchsia-400/40 transition-all backdrop-blur;
   }
 }

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -58,43 +58,43 @@ export default function Contact() {
   };
 
   return (
-    <section className="pt-32 pb-20 px-6 bg-gradient-to-b from-black via-gray-950 to-black min-h-screen">
+    <section className="pt-32 pb-20 px-6 bg-gradient-to-b from-[#050013] via-[#0b0121] to-[#050013] min-h-screen">
       <div className="max-w-3xl mx-auto">
         <Breadcrumbs />
 
         <div className="mb-12 text-center">
           <div className="flex items-center justify-center gap-3 mb-4">
-            <MessageSquare className="w-12 h-12 text-gray-400" />
+            <MessageSquare className="w-12 h-12 text-sky-300" />
             <h1 className="text-5xl font-bold">
-              <span className="bg-gradient-to-r from-gray-200 to-gray-400 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">
                 Contact Support
               </span>
             </h1>
           </div>
-          <p className="text-xl text-gray-400">
-            We're here to help. Send us a message and we'll respond within 24 hours.
+          <p className="text-xl text-violet-100/80">
+            We’re here to help. Submit a ticket and the Eclipse Hub success pod will respond within one business day.
           </p>
         </div>
 
         {success ? (
-          <div className="bg-gradient-to-br from-green-900/30 to-green-900/10 border border-green-500/30 rounded-lg p-8 text-center">
-            <CheckCircle className="w-16 h-16 text-green-500 mx-auto mb-4" />
+          <div className="bg-gradient-to-br from-emerald-500/20 via-teal-500/10 to-emerald-500/20 border border-emerald-400/30 rounded-2xl p-8 text-center">
+            <CheckCircle className="w-16 h-16 text-emerald-300 mx-auto mb-4" />
             <h2 className="text-2xl font-bold mb-2">Ticket Submitted!</h2>
-            <p className="text-gray-400 mb-4">
-              We've received your support ticket and will get back to you within 24 hours.
+            <p className="text-violet-100/80 mb-4">
+              We’ve received your support ticket and will get back to you shortly with next steps.
             </p>
             <button
               onClick={() => setSuccess(false)}
-              className="bg-gradient-to-r from-gray-600 to-gray-500 text-white px-6 py-3 rounded-lg font-medium hover:from-gray-500 hover:to-gray-400 transition-all"
+              className="bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white px-6 py-3 rounded-xl font-medium hover:from-fuchsia-400 hover:via-purple-400 hover:to-sky-300 transition-all"
             >
               Submit Another Ticket
             </button>
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="bg-gray-900/50 border border-gray-800 rounded-lg p-6">
+            <div className="bg-white/10 border border-white/15 rounded-2xl p-6">
               <div className="mb-6">
-                <label className="block text-sm font-medium text-gray-300 mb-2">
+                <label className="block text-sm font-medium text-violet-100/80 mb-2">
                   Priority
                 </label>
                 <div className="grid grid-cols-3 gap-3">
@@ -105,8 +105,8 @@ export default function Contact() {
                       onClick={() => setPriority(p)}
                       className={`px-4 py-3 rounded-lg font-medium transition-all ${
                         priority === p
-                          ? 'bg-gradient-to-r from-gray-600 to-gray-500 text-white'
-                          : 'bg-gray-900 text-gray-400 border border-gray-800 hover:border-gray-700'
+                          ? 'bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white shadow-[0_15px_35px_rgba(124,58,237,0.35)]'
+                          : 'bg-[#08001c] text-violet-100/70 border border-white/10 hover:border-fuchsia-400/40'
                       }`}
                     >
                       {p.charAt(0).toUpperCase() + p.slice(1)}
@@ -116,41 +116,41 @@ export default function Contact() {
               </div>
 
               <div className="mb-6">
-                <label className="block text-sm font-medium text-gray-300 mb-2">
+                <label className="block text-sm font-medium text-violet-100/80 mb-2">
                   Subject
                 </label>
                 <input
                   type="text"
                   value={subject}
                   onChange={e => setSubject(e.target.value)}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:border-gray-600 transition-colors"
+                  className="w-full bg-[#08001c] border border-white/10 rounded-xl px-4 py-3 text-white placeholder-violet-100/40 focus:border-fuchsia-400/40 transition-colors"
                   placeholder="Brief description of your issue"
                   required
                 />
               </div>
 
               <div className="mb-6">
-                <label className="block text-sm font-medium text-gray-300 mb-2">
+                <label className="block text-sm font-medium text-violet-100/80 mb-2">
                   Message
                 </label>
                 <textarea
                   value={message}
                   onChange={e => setMessage(e.target.value)}
                   rows={8}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:border-gray-600 transition-colors resize-none"
+                  className="w-full bg-[#08001c] border border-white/10 rounded-xl px-4 py-3 text-white placeholder-violet-100/40 focus:border-fuchsia-400/40 transition-colors resize-none"
                   placeholder="Provide as much detail as possible about your issue..."
                   required
                 />
               </div>
 
               {error && (
-                <div className="mb-6 p-4 bg-red-500/10 border border-red-500/20 rounded-lg text-red-400 text-sm">
+                <div className="mb-6 p-4 bg-rose-500/15 border border-rose-400/30 rounded-xl text-rose-200 text-sm">
                   {error}
                 </div>
               )}
 
               {!user && (
-                <div className="mb-6 p-4 bg-yellow-500/10 border border-yellow-500/20 rounded-lg text-yellow-400 text-sm">
+                <div className="mb-6 p-4 bg-amber-400/15 border border-amber-300/30 rounded-xl text-amber-200 text-sm">
                   Please sign in to submit a support ticket
                 </div>
               )}
@@ -158,20 +158,20 @@ export default function Contact() {
               <button
                 type="submit"
                 disabled={loading || !user}
-                className="w-full bg-gradient-to-r from-gray-600 to-gray-500 text-white py-3 rounded-lg font-medium hover:from-gray-500 hover:to-gray-400 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
+                className="w-full bg-gradient-to-r from-fuchsia-500 via-purple-500 to-sky-400 text-white py-3 rounded-xl font-medium hover:from-fuchsia-400 hover:via-purple-400 hover:to-sky-300 transition-all disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
               >
                 <Send className="w-5 h-5" />
                 {loading ? 'Submitting...' : 'Submit Ticket'}
               </button>
             </div>
 
-            <div className="bg-gradient-to-br from-gray-900/50 to-gray-900/30 border border-gray-800 rounded-lg p-6">
+            <div className="bg-gradient-to-br from-white/10 via-white/5 to-white/10 border border-white/15 rounded-2xl p-6">
               <h3 className="text-lg font-bold mb-3 flex items-center gap-2">
-                <Mail className="w-5 h-5 text-gray-400" />
+                <Mail className="w-5 h-5 text-sky-300" />
                 Other Ways to Reach Us
               </h3>
-              <div className="space-y-2 text-gray-400">
-                <p>Email: support@alxne.com</p>
+              <div className="space-y-2 text-violet-100/80">
+                <p>Email: support@eclipcestore.digital</p>
                 <p>Live Chat: Available 24/7 (Premium customers)</p>
                 <p>Response Time: Within 24 hours</p>
               </div>

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -3,23 +3,23 @@ import Breadcrumbs from '../components/Breadcrumbs';
 
 export default function PrivacyPolicy() {
   return (
-    <section className="pt-32 pb-20 px-6 bg-gradient-to-b from-black via-gray-950 to-black min-h-screen">
+    <section className="pt-32 pb-20 px-6 bg-gradient-to-b from-[#050013] via-[#0b0121] to-[#050013] min-h-screen">
       <div className="max-w-4xl mx-auto">
         <Breadcrumbs />
 
         <div className="mb-12 text-center">
           <div className="flex items-center justify-center gap-3 mb-4">
-            <Shield className="w-12 h-12 text-gray-400" />
+            <Shield className="w-12 h-12 text-sky-300" />
             <h1 className="text-5xl font-bold">
-              <span className="bg-gradient-to-r from-gray-200 to-gray-400 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">
                 Privacy Policy
               </span>
             </h1>
           </div>
-          <p className="text-gray-400">Last updated: {new Date().toLocaleDateString()}</p>
+          <p className="text-violet-100/70">Last updated: {new Date().toLocaleDateString()}</p>
         </div>
 
-        <div className="bg-gray-900/50 border border-gray-800 rounded-lg p-8 space-y-8 text-gray-300">
+        <div className="bg-white/10 border border-white/15 rounded-2xl p-8 space-y-8 text-violet-100/80 shadow-[0_25px_60px_rgba(56,189,248,0.25)]">
           <section>
             <h2 className="text-2xl font-bold text-white mb-4">1. Information We Collect</h2>
             <p className="mb-4">We collect the following types of information:</p>
@@ -99,7 +99,7 @@ export default function PrivacyPolicy() {
               <li>Withdraw consent at any time</li>
             </ul>
             <p className="mt-4">
-              To exercise these rights, contact us at privacy@alxne.com
+              To exercise these rights, contact us at privacy@eclipcestore.digital
             </p>
           </section>
 
@@ -157,10 +157,10 @@ export default function PrivacyPolicy() {
             <p className="mb-4">
               For questions or concerns about this Privacy Policy or our data practices:
             </p>
-            <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
-              <p>Email: privacy@alxne.com</p>
-              <p>Support: support@alxne.com</p>
-              <p className="mt-2">Data Protection Officer: dpo@alxne.com</p>
+            <div className="bg-white/5 border border-white/10 rounded-xl p-4">
+              <p>Email: privacy@eclipcestore.digital</p>
+              <p>Support: support@eclipcestore.digital</p>
+              <p className="mt-2">Data Protection Officer: dpo@eclipcestore.digital</p>
             </div>
           </section>
         </div>

--- a/src/pages/TermsOfService.tsx
+++ b/src/pages/TermsOfService.tsx
@@ -3,27 +3,27 @@ import Breadcrumbs from '../components/Breadcrumbs';
 
 export default function TermsOfService() {
   return (
-    <section className="pt-32 pb-20 px-6 bg-gradient-to-b from-black via-gray-950 to-black min-h-screen">
+    <section className="pt-32 pb-20 px-6 bg-gradient-to-b from-[#050013] via-[#0b0121] to-[#050013] min-h-screen">
       <div className="max-w-4xl mx-auto">
         <Breadcrumbs />
 
         <div className="mb-12 text-center">
           <div className="flex items-center justify-center gap-3 mb-4">
-            <FileText className="w-12 h-12 text-gray-400" />
+            <FileText className="w-12 h-12 text-fuchsia-400" />
             <h1 className="text-5xl font-bold">
-              <span className="bg-gradient-to-r from-gray-200 to-gray-400 bg-clip-text text-transparent">
+              <span className="bg-gradient-to-r from-fuchsia-300 via-purple-200 to-sky-200 bg-clip-text text-transparent">
                 Terms of Service
               </span>
             </h1>
           </div>
-          <p className="text-gray-400">Last updated: {new Date().toLocaleDateString()}</p>
+          <p className="text-violet-100/70">Last updated: {new Date().toLocaleDateString()}</p>
         </div>
 
-        <div className="bg-gray-900/50 border border-gray-800 rounded-lg p-8 space-y-8 text-gray-300">
+        <div className="bg-white/10 border border-white/15 rounded-2xl p-8 space-y-8 text-violet-100/80 shadow-[0_25px_60px_rgba(56,189,248,0.25)]">
           <section>
             <h2 className="text-2xl font-bold text-white mb-4">1. Acceptance of Terms</h2>
             <p className="mb-4">
-              By accessing and using ALXNE's services, you accept and agree to be bound by the terms
+              By accessing and using Eclipse Hub's services, you accept and agree to be bound by the terms
               and provision of this agreement. If you do not agree to these terms, please do not use
               our services.
             </p>
@@ -32,7 +32,7 @@ export default function TermsOfService() {
           <section>
             <h2 className="text-2xl font-bold text-white mb-4">2. License Usage</h2>
             <p className="mb-4">
-              When you purchase a digital product or license from ALXNE, you are granted a
+              When you activate a service subscription through Eclipse Hub, you are granted a
               non-exclusive, non-transferable license to use the product according to its specific
               terms. License keys are for personal or business use as specified in the product
               description.
@@ -58,7 +58,7 @@ export default function TermsOfService() {
             <h2 className="text-2xl font-bold text-white mb-4">4. Account Security</h2>
             <p className="mb-4">
               You are responsible for maintaining the confidentiality of your account credentials.
-              ALXNE is not liable for any loss or damage resulting from unauthorized access to your
+              Eclipse Hub is not liable for any loss or damage resulting from unauthorized access to your
               account due to your failure to maintain security.
             </p>
           </section>
@@ -78,7 +78,7 @@ export default function TermsOfService() {
           <section>
             <h2 className="text-2xl font-bold text-white mb-4">6. Intellectual Property</h2>
             <p className="mb-4">
-              All content, trademarks, and intellectual property on ALXNE remain the property of
+              All content, trademarks, and intellectual property on Eclipse Hub remain the property of
               their respective owners. Your purchase grants you a license to use, not ownership of
               the underlying intellectual property.
             </p>
@@ -87,7 +87,7 @@ export default function TermsOfService() {
           <section>
             <h2 className="text-2xl font-bold text-white mb-4">7. Limitation of Liability</h2>
             <p className="mb-4">
-              ALXNE shall not be liable for any indirect, incidental, special, consequential, or
+              Eclipse Hub shall not be liable for any indirect, incidental, special, consequential, or
               punitive damages resulting from your use of our services. Our total liability shall not
               exceed the amount paid by you for the specific product or service.
             </p>
@@ -114,9 +114,9 @@ export default function TermsOfService() {
             <p className="mb-4">
               For questions about these Terms of Service, please contact us at:
             </p>
-            <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
-              <p>Email: legal@alxne.com</p>
-              <p>Support: support@alxne.com</p>
+            <div className="bg-white/5 border border-white/10 rounded-xl p-4 text-violet-100/80">
+              <p>Email: legal@eclipcestore.digital</p>
+              <p>Support: support@eclipcestore.digital</p>
             </div>
           </section>
         </div>

--- a/src/pages/admin/AdminLogin.tsx
+++ b/src/pages/admin/AdminLogin.tsx
@@ -51,7 +51,7 @@ export default function AdminLogin() {
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   className="w-full pl-10 pr-4 py-3 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:border-gray-600 focus:outline-none transition-colors"
-                  placeholder="admin@alxne.com"
+                  placeholder="admin@eclipcestore.digital"
                   required
                 />
               </div>


### PR DESCRIPTION
## Summary
- restyled the marketing experience with Eclipse Hub branding, neon gradients, and updated calls to action across the landing components
- refreshed legal, contact, and footer content to reference eclipcestore.digital and new service messaging
- aligned supporting assets like admin defaults and metadata with the Eclipse Hub identity

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2bff3afc48330ae4b75abb97e03fe